### PR TITLE
Get around tty paste line length limits

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,32 +2,41 @@
 
 
 [[projects]]
+  digest = "1:87d728b37c52817c6180111f985ee56f5c2615c9d3709049c6bf6cee7b2307e8"
   name = "github.com/Shopify/ejson"
   packages = ["crypto"]
+  pruneopts = "UT"
   revision = "ce9261f21575d3fb0ceda6795935ddd8800563a9"
   version = "1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:dd1417c60900a2be6d1653e90306614657761fc9c3066eccc558ae432b31aa60"
   name = "github.com/atotto/clipboard"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5e2c7bddca04488284428a201e4a15615f7a5074"
 
 [[projects]]
   branch = "master"
+  digest = "1:5b5bfb4cd557a7ce3cbb23492bf670204c81827f5f2ab70ad03b206661f0ed7b"
   name = "golang.org/x/crypto"
   packages = [
     "curve25519",
     "nacl/box",
     "nacl/secretbox",
     "poly1305",
-    "salsa20/salsa"
+    "salsa20/salsa",
   ]
+  pruneopts = "UT"
   revision = "ab813273cd59e1333f7ae7bff5d027d4aadf528c"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "badf294ed4440119222d347b57c3111929b23da9b565eb7569e424ffe5b4ce14"
+  input-imports = [
+    "github.com/Shopify/ejson/crypto",
+    "github.com/atotto/clipboard",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ These messages are not secret so they can be sent over (e.g.) Slack.
 
 1. The user receving the secret token or password will run `secret-sender receive`. This will copy their public key to the clipboard and display it in their shell.
 2. The receiving user will message that public key to the sender.
-3. The sender will run `secret-sender send`, paste the public key into their shell, and press return.
-4. The sender will then be prompted to paste their secret and press return.
+3. The sender will run `secret-sender send`, paste the public key into their shell, and press Enter/Return.
+4. The sender will then be prompted to copy their secret to their clipboard and press Enter/Return.
 5. secret-sender will copy the encrypted string to the clipboard and display it in the shell.
 6. The sender will message that encrypted string to the receiver.
-7. The receiver pastes that encrypted string into their shell and presses return.
+7. The receiver copies that encrypted string into their clip and presses Enter/Return in secret-sender.
 8. secret-sender displays the secret in the shell.
 
 
@@ -29,7 +29,6 @@ These messages are not secret so they can be sent over (e.g.) Slack.
 Secret-sender uses NaCl Box cryptograpy, or curve25519xsalsa20poly1305.
 The receiver generates an ephemeral keypair and sends the public portion to the sender, who encrypts the secret to that key, before sending the ciphertext to the receiver. The receiver then recovers the plaintext and terminates, discarding the private key.
 
-Neither subcommand takes any arguments, but both ask for user input.
+Neither subcommand takes any arguments, but both ask the sender and receiver to copy their plaintext and ciphertext (respectively) into their clipboard once the program is running.
 
-Scripting this is discouraged: Use ejson directly.
-
+Scripting with secret-sender is discouraged: instead, use [ejson](http://github.com/Shopify/ejson) directly.

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func sendSecret() {
 	fmt.Println("Ask the receiving party to run `secret-sender receive` and send you the public key that it generates.")
 	fmt.Println("Paste the public key here:")
 	pk := readline()
+
 	bytes, err := hex.DecodeString(string(pk))
 	if err != nil {
 		log.Fatal(err)
@@ -49,16 +50,19 @@ func sendSecret() {
 		log.Fatal(err)
 	}
 
-	fmt.Println("Paste your secret here:")
-	plaintext := readline()
+	fmt.Println("Copy your secret to your clipboard, then press Enter/Return:")
+	readEnter()
+	plaintext := pbpaste()
 
 	encrypter := crypto.NewEncrypter(&ephemeralKP, receiverKP.Public)
 	ciphertext, err := encrypter.Encrypt(plaintext)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println("This is the encrypted string. Paste it to the receiver. (We've already put it in your clipboard):")
+
 	pbcopy(string(ciphertext))
+
+	fmt.Println("This is the encrypted string. Paste it to the receiver. (We've already put it in your clipboard):")
 	fmt.Println(string(ciphertext))
 }
 
@@ -67,12 +71,14 @@ func receiveSecret() {
 	if err := kp.Generate(); err != nil {
 		log.Fatal(err)
 	}
+
 	fmt.Println("Paste this key to the sender (we've already put it in your clipboard):")
 	pbcopy(kp.PublicString())
 	fmt.Println(kp.PublicString())
-	fmt.Println("They'll respond with a big encrypted-looking blob. Paste it here, then press return:")
 
-	ciphertext := readline()
+	fmt.Println("They'll respond with a big encrypted-looking blob. Copy it to your clip board, then press Enter/Return:")
+	readEnter()
+	ciphertext := pbpaste()
 
 	decrypter := &crypto.Decrypter{Keypair: &kp}
 	plaintext, err := decrypter.Decrypt(ciphertext)
@@ -88,6 +94,10 @@ func usageAndDie() {
 	os.Exit(1)
 }
 
+func readEnter() {
+	fmt.Scanln()
+}
+
 func readline() []byte {
 	line, _, err := stdin.ReadLine()
 	if err != nil {
@@ -100,4 +110,13 @@ func pbcopy(text string) {
 	if err := clipboard.WriteAll(text); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func pbpaste() []byte {
+	text, err := clipboard.ReadAll()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return []byte(text)
 }


### PR DESCRIPTION
Closes https://github.com/Shopify/secret-sender/issues/3

Today while using this program for the first time, I ran into an issue receiving a secret that encrypted to a string longer than 1024 characters. I believe this character limit is set in OS X https://superuser.com/a/219304 and isn't configurable within the application (with the stdin buffer size) and it's obviously well below the byte limit that the OS clipboard can hold.

As explained in the updated README, this PR attempts to get around this by simply making use of the existing clipboard package's `ReadAll` method, and changes the workflow to have senders/receives copy their plaintext/ciphertext to their clipboard, and simply hit Enter/Return to kick off the encryption/decryption.